### PR TITLE
Add more information to logged in user's profile

### DIFF
--- a/UserProfile.js
+++ b/UserProfile.js
@@ -64,10 +64,23 @@ class UserProfile extends Component {
     render() {
 
       return (
-        <View style={styles.container}>
+        <View>
+          <Image style={styles.backgroundImage}
+            source={{uri: "https://snap-photos.s3.amazonaws.com/img-thumbs/960w/X7O1GI92GY.jpg"}}
+            width={380}
+            height={200}/>
+
+          <Image source={{uri: this.state.user.image_url}}
+            style={styles.thumbnail} />
             <View style={{flex: 1, flexDirection: 'column', alignItems: 'center', justifyContent: 'center',}}>
-                <Text style={styles.title}>
-                    {this.state.user.username}
+                <Text  style={styles.title}>
+                   {this.state.user.username}
+                </Text>
+                <Text>
+                   {this.state.user.city}, {this.state.user.state} {this.state.user.zipcode}
+                </Text>
+                <Text style={styles.description}>
+                   {this.state.user.bio}
                 </Text>
             </View>
         <TouchableHighlight style={styles.button} onPress={this.onLogout.bind(this)}>
@@ -75,7 +88,7 @@ class UserProfile extends Component {
             Logout
           </Text>
         </TouchableHighlight>
-              </View>
+        </View>
           );
       }
 
@@ -84,22 +97,22 @@ class UserProfile extends Component {
 
 var styles = StyleSheet.create({
     container: {
-        marginTop: 65,
-        padding: 30
+        // marginTop: 65,
+        // padding: 30,
+        // height: 600
     },
     thumbnail: {
       width: 200,
       height: 150,
-      marginLeft: 60,
+      marginLeft: 80,
       borderWidth: 1,
-      borderColor: "black",
-      marginTop: 30
+      borderColor: "white",
+      marginTop: -110
     },
     title: {
       flex: 1,
       fontSize: 25,
-      marginTop: 10,
-      marginBottom: 8,
+      margin: 10
     },
     image: {
       width: 107,
@@ -108,15 +121,21 @@ var styles = StyleSheet.create({
     },
     description: {
       padding: 10,
-      fontSize: 15,
-      color: '#656565'
+      fontSize: 13,
+      color: '#656565',
+      marginLeft: 15,
+      marginRight: 15
+    },
+    backgroundImage: {
     },
     button: {
       height: 50,
       backgroundColor: '#48BBEC',
       alignSelf: 'stretch',
       marginTop: 10,
-      justifyContent: 'center'
+      justifyContent: 'center',
+      margin: 10,
+      borderRadius: 5
     },
     buttonText: {
       fontSize: 22,


### PR DESCRIPTION
The profile page for the currently logged in user only contained
their name and a logout button so texts were placed to show their
city, state, zipcode, and bio. Nothing can be edited once entered
during registration though.
